### PR TITLE
Updated dada2.smk to add temp output and gracefully handle files that…

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -77,7 +77,7 @@ rule dada2:
       batch = batches, sample = all_samples, allow_missing = True),
     expand("output/dada2/asv_batch/{batch}_asv.qs", batch = batches),
     expand("output/dada2/asv_batch/{batch}_summary.tsv", batch = batches),
-    "output/dada2/after_qc/asv_mat_wo_chim.qs"
+    "output/dada2/after_qc/asv_mat_wo_chim.qs",
     "workflow/report/dada2qc/asv_matrix_wo_chim.png",
     "workflow/report/dada2qc/nasvs_by_seqlength.png",
     "workflow/report/dada2qc/nasvs_by_seqabundance.png",


### PR DESCRIPTION
Updated Snakemake file - there was a comma missing from the input list to rule dada2 

Updated dada2.smk to:
-- take negative control file location from config.yaml instead of hardcoding
-- make some outputs temporary (filtered fastqs and per-sample asv .qs files)
-- gracefully handle samples that were completely filtered during filter and trim -- at least up to learn_error_rates -- not sure if it works all the way through the pipeline yet
-- only learn error rates for R1 or R2 at a time - previously it was putting all R1s and R2s in for each batch