### PR TITLE
updated gather_derep_seqtab with input validation

### DIFF
--- a/workflow/scripts/dada2/gather_derep_seqtab.R
+++ b/workflow/scripts/dada2/gather_derep_seqtab.R
@@ -17,7 +17,7 @@ gather_derep_seqtab.R --version
 
 Options:
 -h --help    show this screen
---log=<logfile>    name of the log file [default: filter_and_trim.log]
+--log=<logfile>    name of the log file [default: gather_derep_seqtab.log]
 --config=<cfile>    name of the yaml file with the parameters [default: ./config/config.yaml]" -> doc
 
 library(docopt)
@@ -36,8 +36,8 @@ if (!interactive()) {
 
 if (interactive()) {
 
-  arguments$batch <- "dust_dec2019"
-  arguments$asv_file <- "dust_dec2019_asv.qs"
+  arguments$batch <- "batch2018"
+  arguments$asv_file <- "batch2018_asv.qs"
   arguments$derep_file <- list.files(file.path("output", "dada2",
     "merge", arguments$batch), full.names = TRUE)
 
@@ -61,19 +61,68 @@ derep_files <- arguments$derep_file
 
 stopifnot(any(file.exists(derep_files)), file.exists(arguments$config))
 
+# Identify and remove empty files.
+# These are placeholder files that were created
+# to appease snakemake after all reads were
+# filtered out from the input file back in filter_and_trim.
+# stop if we have no files left after checking for empty.
+derep_tb <- tibble(derep_file = derep_files) %>%
+  dplyr::mutate(size = purrr::map(derep_file, ~ file.info(.x)$size)) %>%
+  dplyr::mutate(key = purrr::map(derep_file,
+    ~ basename(.x) %>% gsub("_asv.qs", "", .)) ) %>%
+  unnest(c(key, size))
+  
+count_nonempty <- derep_tb %>% 
+  dplyr::filter(size>0) %>%
+  nrow()
+stopifnot(count_nonempty>0)
+
+# read ASV files
+read_merger <- function(filename, size) {
+  if (size == 0) {
+    NULL
+  } else {
+    qs::qread(filename)
+  }
+}
+derep_tb %<>%
+  dplyr::mutate(derep_merger = purrr::map2(derep_file,size, read_merger)) %>%
+  dplyr::mutate(mergers = purrr::map(derep_merger, "merge")) %>%
+  dplyr::mutate(dada_fwd = purrr::map(derep_merger, "dada_fwd")) %>%
+  dplyr::mutate(dada_bwd = purrr::map(derep_merger, "dada_bwd")) 
+
+####  
+
 config <- yaml::read_yaml(arguments$config)
 
 stopifnot(file.exists(config$sample_table))
-sample_names <- readr::read_tsv(config$sample_table) %>%
-  dplyr::filter(batch == arguments$batch) %>%
-  dplyr::pull(key)
+#sample_names <- readr::read_tsv(config$sample_table) %>%
+#  dplyr::filter(batch == arguments$batch) #%>%
+#  dplyr::pull(key)
+sample_tb <- readr::read_tsv(config$sample_table) %>%
+  left_join(derep_tb) 
 
-derep_mergers <- purrr::map(derep_files, qs::qread)
-mergers <- purrr::map(derep_mergers, "merge")
-names(mergers) <- sample_names
+# now do some checking to make sure we only have
+# the correct batch in the input
+check_batches <- sample_tb %>% 
+  dplyr::filter(!is.na(derep_file)) %>%
+  dplyr::count(batch)
+if (nrow(check_batches) > 1) {
+  message("User supplied input derep files from multiple batch(es):")
+  message(paste(sprintf("%s: %d", check_batches$batch, check_batches$n),
+    collapse = "\n"))
+  message("We will only look at the requested batch: ", arguments$batch)
+}
 
-dada_fwd <- purrr::map(derep_mergers, "dada_fwd")
-dada_bwd <- purrr::map(derep_mergers, "dada_bwd")
+# remove other batches, but keep empty files for summary
+sample_tb %<>%
+  dplyr::filter(batch == arguments$batch)
+nonempty_tb <- sample_tb %>%
+  dplyr::filter(size>0)
+mergers <- pluck(nonempty_tb, "mergers") %>%
+  setNames(pluck(nonempty_tb, "key"))
+dada_fwd <- pluck(nonempty_tb, "dada_fwd")
+dada_fwd <- pluck(nonempty_tb, "dada_bwd")
 
 message("creating sequence table")
 seqtab <- dada2::makeSequenceTable(mergers)
@@ -83,15 +132,29 @@ qs::qsave(seqtab, arguments$asv_file)
 message("summarizing results")
 
 ## get N reads
-get_nreads <- function(x) sum(dada2::getUniques(x))
+## include lost samples with 0s
+get_nreads <- function(x) {
+    if (!is.null(x)) {
+        sum(dada2::getUniques(x))
+    } else {
+      NA
+    }}
+track <- sample_tb %>%
+  dplyr::mutate(denoised = purrr::map(dada_fwd, get_nreads)) %>%
+  dplyr::mutate(merged = purrr::map(mergers, get_nreads)) %>%
+  unnest(c(denoised, merged)) %>%
+  dplyr::transmute(samples = key, denoised, merged) %>%
+  dplyr::mutate(across(c(denoised, merged), ~replace_na(.x, 0)))
 
-track <- cbind(
-    sapply(dada_fwd, get_nreads), sapply(mergers, get_nreads))
-colnames(track) <- c("denoised", "merged")
+#track <- cbind(
+#    sapply(dada_fwd, get_nreads), sapply(mergers, get_nreads))
+#colnames(track) <- c("denoised", "merged")
 
+#track %>%
+#  as.data.frame() %>%
+#  tibble::as_tibble(rownames = "samples") 
+#  %>%
 track %>%
-  as.data.frame() %>%
-  tibble::as_tibble(rownames = "samples") %>%
   readr::write_tsv(arguments$summary_file)
 
 message("Done! summary file at ", arguments$summary_file)


### PR DESCRIPTION
- Checks for empty input files. Does not try to put them in the merged asv table, but does add them to the summary file (with 0 for merged and denoised)
- Checks for input files from the wrong batch. Does not include them in the merged asv_table.
- Original script assumed input filenames would be in order of sample table keys. This may be true in the snakemake pipeline, but it is not guaranteed (for example, when testing, I got filenames with list.files and the order put sample_88 after sample_400). Updated to extract "sample_*" key from input filename and join to the sample table. We will only be looking at files that have keys in the sample table.
- Updated default log file name (no big deal)