### PR TITLE
Fixed remove_chimeras.R when some samples are missing from the seqtab

### DIFF
--- a/workflow/scripts/dada2/remove_chimeras.R
+++ b/workflow/scripts/dada2/remove_chimeras.R
@@ -12,7 +12,7 @@ remove_chimeras.R --version
 
 Options:
 -h --help    show this screen
---log=<logfile>    name of the log file [default: filter_and_trim.log]
+--log=<logfile>    name of the log file [default: remove_chimeras.log]
 --config=<cfile>    name of the yaml file with the parameters [default: ./config/config.yaml]
 --cores=<cores>    number of CPUs for parallel processing [default: 24]" -> doc
 
@@ -103,11 +103,18 @@ outmat <- seqtab[, seq_len(min(1e4, ncol(seqtab)))]
 outmat <- ifelse(outmat > 0, 1, 0)
 cols <- structure(c("black", "white"), names = c("1", "0"))
 
-annot <- ComplexHeatmap::rowAnnotation(
-  df = sample_table %>%
+
+# put row annotation in same order as matrix
+# will remove samples that were completely empty
+# after filter_and_trim
+anno_df <- sample_table %>%
     select(batch, key) %>%
     as.data.frame() %>%
-    column_to_rownames("key"),
+    column_to_rownames("key")
+anno_df <- anno_df[rownames(outmat), , drop=F]
+
+annot <- ComplexHeatmap::rowAnnotation(
+  df = anno_df,
   annotation_legend_param = list(
     batch = list(direction = "horizontal")))
 


### PR DESCRIPTION
When we make the spy heatmap, we add batch annotation to the samples. Previously, this assumed that all samples from the original sample table would be found in the seqtab. However, if we have input samples that are all 0, we may or may not have them in the resulting seqtab file (depending on how we resolve the gather_derep_seqtab, I guess). I updated this so that it only takes batch annotations for samples that are in the seqtab.